### PR TITLE
Facebook uses its own domain for CDN now

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Sources for some of the rules:
 * facebook.com * block
 * facebook.net * block
 facebook.com facebook.com * allow
-facebook.com fbstatic-a.akamaihd.net * allow
+facebook.com fbcdn.net * allow
 ```
 
 ### Twitter


### PR DESCRIPTION
Just a quick PR, seems to be another case of outdated ruleset having been sourced elsewhere.